### PR TITLE
adding unit testcases for userService

### DIFF
--- a/src/test/java/com/hytejasvi/taskManagementApp/service/UserServiceTests.java
+++ b/src/test/java/com/hytejasvi/taskManagementApp/service/UserServiceTests.java
@@ -1,0 +1,63 @@
+package com.hytejasvi.taskManagementApp.service;
+
+import com.hytejasvi.taskManagementApp.dto.UserDto;
+import com.hytejasvi.taskManagementApp.entity.User;
+import com.hytejasvi.taskManagementApp.repository.UserRepository;
+import com.hytejasvi.taskManagementApp.utils.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+
+@SpringBootTest
+public class UserServiceTests {
+
+    @Autowired
+    private UserService userService;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private UserDetailsServiceImpl userDetailsService;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    private User sampleUser;
+    private UserDto sampleUserDto;
+
+    @BeforeEach
+    public void setup() {
+        sampleUser = new User();
+        sampleUser.setUserName("testUser");
+        sampleUser.setPassword("password");
+        sampleUser.setMailId("test@example.com");
+
+        sampleUserDto = new UserDto();
+        sampleUserDto.setUserName("testUser");
+        sampleUserDto.setPassword("password");
+        sampleUserDto.setEmailId("test@example.com");
+    }
+
+    @Test
+    public void testCreateUserWithValidInput(){
+        when(userRepository.save(any(User.class))).thenReturn(sampleUser);
+        userService.createUser(sampleUser);
+        verify(userRepository, times(1)).save(sampleUser);
+
+    }
+
+    @Test
+    public void testCreateUserWithEmptyUserName() {
+        sampleUser.setUserName("");
+        assertThrows(IllegalArgumentException.class, () -> userService.createUser(sampleUser));
+    }
+}


### PR DESCRIPTION
The @MockBean annotation in Spring Boot is used to create and inject a mock version of a Spring-managed bean. In this case, we’re creating a mock instance of UserRepository
The @BeforeEach annotation is a feature that indicates the setUp method should be executed before each test method.

The save method of userRepository is being mocked. The any(User.class) is a Mockito argument matcher that allows any User object to be passed to the save method. It means that no matter what User object is passed to save, this mock will be triggered.

thenReturn(sampleUser): This part specifies the behavior of the mocked save method. It tells Mockito that when save is called, it should return the sampleUser object.

userService.createUser(sampleUser);
This line is calling the actual method you are testing, createUser, in the userService class. We are passing the sampleUser object to it.

Since we have mocked the userRepository.save() method earlier, calling createUser() will trigger the mocked behavior of save (i.e., returning the sampleUser object).
The actual behavior of createUser should be tested — ensuring that it processes the input, performs the required validation, and interacts with the repository as expected.


verify(userRepository, times(1)).save(sampleUser);
This is a verification step to ensure that the save method was called exactly once during the execution of createUser.

verify(...): This is used to check if a specific method was called on a mock object.

userRepository: The mock object that we want to verify interactions with.

times(1): This specifies the expected number of times the save method should have been called. In this case, it should be called exactly once.

save(sampleUser): This verifies that the save method was called with the exact sampleUser object passed as an argument.